### PR TITLE
Update for running idempotently within CI/CD pipeline

### DIFF
--- a/Get-SSMSDiagramCode.ps1
+++ b/Get-SSMSDiagramCode.ps1
@@ -150,7 +150,7 @@ set xact_abort, nocount on;
 
 if @@trancount > 0
 begin
-    throw 50000, N'This procedure must not be executed within an open transaction.', 1;
+    ; throw 50000, N'This procedure must not be executed within an open transaction.', 1;
     return 1;
 end
 
@@ -225,7 +225,7 @@ set xact_abort, nocount on;
 
 if @@trancount > 0
 begin
-    throw 50000, N'This procedure must not be executed within an open transaction.', 1;
+    ; throw 50000, N'This procedure must not be executed within an open transaction.', 1;
     return 1;
 end
 

--- a/Get-SSMSDiagramCode.ps1
+++ b/Get-SSMSDiagramCode.ps1
@@ -135,7 +135,12 @@ $ResultsGrouped = $Results | Group-Object -Property diagram_id
 ############################################
 
 $GenerationProcedureNames = @()
-$OutputSql = ""
+$OutputSql = "
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'$($DiagramSchema)')
+    EXEC('CREATE SCHEMA [$($DiagramSchema)] AUTHORIZATION [dbo]');
+GO
+
+"
 
 foreach ($Group in $ResultsGrouped) {
     $LastRow = $Group.Group[-1]

--- a/Get-SSMSDiagramCode.ps1
+++ b/Get-SSMSDiagramCode.ps1
@@ -10,7 +10,11 @@ param (
     [string] $DiagramSchema = "DiagramGeneration",
 
     [Parameter(Mandatory = $false)]
-    [int] $ChunkSize = 20
+    [int] $ChunkSize = 20,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("Mandatory", "Optional", "Strict")]
+    [string] $Encrypt = "Optional"
 )
 
 ############
@@ -48,7 +52,8 @@ $DiagramTableExists = Invoke-SqlCmd `
     -ConnectionTimeout 5 `
     -OutputAs DataTables `
     -QueryTimeout 5 `
-    -Query $DiagramTableExistsQuery
+    -Query $DiagramTableExistsQuery `
+    -Encrypt $Encrypt
 
 if ($DiagramTableExists[0].DiagramTableExists -eq 0) {
     Write-Host "The dbo.sysdiagrams table does not exist"
@@ -114,7 +119,8 @@ $Results = Invoke-SqlCmd `
     -OutputAs DataTables `
     -QueryTimeout 30 `
     -Query $Query `
-    -Variable $Variables
+    -Variable $Variables `
+    -Encrypt $Encrypt
 
 if ($null -eq $Results) {
     Write-Host "No diagrams exist"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ You can also specify the chunk size (number of bytes per generated `update` stat
 .\Get-SSMSDiagramCode.ps1 -Database StackOverflow2013 -ChunkSize 32
 ```
 
+You can also specify the encryption type to use when connecting to SQL Server using the `-Encrypt` argument:
+```powershell
+.\Get-SSMSDiagramCode.ps1 -Database StackOverflow2013 -Encrypt Optional
+```
+
 By default the generated code will be written to the PowerShell terminal. You can redirect the generated code elsewhere - such as a file - using the `Out-File` cmdlet. For example:
 ```powershell
 .\Get-SSMSDiagramCode.ps1 -Database StackOverflow2013 | Out-File -FilePath generated.sql -Encoding utf8


### PR DESCRIPTION
# Idempotent execution in CICD pipeline and other changes

- Idempotency improvements:
   - The generated SQL code now includes a T-SQL statement that idempotently creates the requisite `DiagramGeneration` schema.
   - The generated SQL code now uses a `CREATE OR ALTER PROCEDURE` statement instead of a `CREATE PROCEDURE` statement.
- Support added for the new `Encrypt` parameter found in new versions of the `SqlServer` PowerShell module.
- New version of `SqlServer` PowerShell module now required: `22.1.1` or higher.