### PR TITLE
Enforce #requires minimum SqlServer module version

### DIFF
--- a/Get-SSMSDiagramCode.ps1
+++ b/Get-SSMSDiagramCode.ps1
@@ -22,7 +22,7 @@ param (
 ############
 
 #requires -Version 5.1
-#requires -Modules SqlServer
+#requires -Modules @{ ModuleName="SqlServer"; ModuleVersion="22.1.1" }
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
Specify the minimum supported version of the `SqlServer` PowerShell module.